### PR TITLE
Rename pages to update top-level menu items in site

### DIFF
--- a/site/content/biggest_impact.md
+++ b/site/content/biggest_impact.md
@@ -25,7 +25,7 @@ os.makedirs('_generated', exist_ok=True)
 from myst_nb import glue
 ```
 
-# The Big Picture
+# Future
 
 ```{code-cell} ipython3
 ---

--- a/site/content/contributions.md
+++ b/site/content/contributions.md
@@ -25,7 +25,7 @@ os.makedirs('_generated', exist_ok=True)
 from myst_nb import glue
 ```
 
-# Community Contributions and Development
+# Contributions
 
 % NOTE: The structure of the NumPy and non-NumPy contributions questions are
 % slightly different.

--- a/site/content/demographics.md
+++ b/site/content/demographics.md
@@ -35,7 +35,7 @@ strip = np.vectorize(str.strip, otypes='U')
 title = np.vectorize(str.title, otypes='U')
 ```
 
-# Demographics and Usage
+# Community
 
 A summary of the demographic information of the NumPy survey respondents.
 

--- a/site/content/features_and_deprecations.md
+++ b/site/content/features_and_deprecations.md
@@ -25,7 +25,7 @@ os.makedirs('_generated', exist_ok=True)
 from myst_nb import glue
 ```
 
-# Features, Problems, and Deprecations
+# Usage
 
 ```{code-cell} ipython3
 ---

--- a/site/content/priorities.md
+++ b/site/content/priorities.md
@@ -25,7 +25,7 @@ os.makedirs('_generated', exist_ok=True)
 from myst_nb import glue
 ```
 
-# Project Priorities
+# Priorities
 
 ```{code-cell} ipython3
 ---


### PR DESCRIPTION
Attempt at addressing point 3 of #12.

Renames the top-level headings with more concise, general names to update the top-level menu bar.

Example of new menubar here: https://rossbar.github.io/numpy-survey-results/