### PR TITLE
Rm notes about links to public data.

### DIFF
--- a/site/content/2021/biggest_impact.md
+++ b/site/content/2021/biggest_impact.md
@@ -65,8 +65,6 @@ glue(
 To conclude the survey, we asked participants to share their thoughts on what
 changes to NumPy would have the most significant impact for them as users.
 
-Note: CSV versions of these text responses can be found in the supplemental text public use data file. [INSERT LINK]
-
 ## Biggest Impact
 
 We asked survey participants the following question:

--- a/site/content/2021/priorities.md
+++ b/site/content/2021/priorities.md
@@ -136,8 +136,6 @@ For example, if a user ranked "Performance" as a top priority, they were asked
 to share any specific thoughts on how performance could be improved.
 The responses for each of the categories are provided below.
 
-Note: CSV versions of these text responses can be found in the supplemental text public use data file. [INSERT LINK]
-
 ```{code-cell} ipython3
 ---
 tags: [hide-input]


### PR DESCRIPTION
Closes #35 

I think it's best to push making data public into it's own separate issue that can be addressed after the release of the 2021 survey.